### PR TITLE
Updated README.md with a little Markdown fix!

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,5 @@ If you get stuck anywhere, hop onto one of our [support channels in discord](htt
 
 ## 📝 License
 
-Copyright © 2021 [Damodar Lohani]](https://github.com/lohanidamodar).<br />
+Copyright © 2021 [Damodar Lohani](https://github.com/lohanidamodar).<br />
 This project is [MIT](./LICENSE.md) licensed.


### PR DESCRIPTION
There is an additional closing square bracket after the hyperlink alt-text, due to which the hyperlink wasn't rendered at the end of the **README.md**.

Therefore, I decided to fix that issue by removing that extra square bracket, therefore making the hyperlink render correctly.